### PR TITLE
Copy image pids to oracle-pid.properties.

### DIFF
--- a/src/main/resources/oracle-pid.properties
+++ b/src/main/resources/oracle-pid.properties
@@ -64,3 +64,12 @@ dynamic.database.end=pid-73599876-e819-448e-a6cc-631e32f9cd7f
 dynamic.database.start=pid-030d078e-2f24-4003-bf3c-a98627680dda
 dynamic.end=pid-18317e1d-f01a-4e65-b796-67b78e60ae8b
 dynamic.start=pid-88e42085-baae-44ec-802d-5df45a1369fe
+
+# Pids to indicate which base image was chosen.  No difference in these
+# between Oracle and Microsoft
+
+from.owls-122130-8u131-ol74=pid-ac3571f9-c12d-5caa-b886-85734693ab63
+from.owls-122130-8u131-ol73=pid-2bd71be8-b31c-5fbf-96ba-61fde622586d
+from.owls-122140-8u251-ol76=pid-dd07bd44-828b-566a-8dc6-b84bf301bf1d
+from.owls-141100-8u251-ol76=pid-cb2af004-23c3-5c85-87b9-9de767c7a61e
+from.owls-141100-11_07-ol76=pid-632e8fde-e61f-57bf-af9d-5804bf00ecb3


### PR DESCRIPTION
Fix build error on develop branch.
develop branch uses pids in oracle-pid.properties for testing, we should copy image pids to this file.