### PR TITLE
Fixes text error.

### DIFF
--- a/admin/aadNestedTemplate.md
+++ b/admin/aadNestedTemplate.md
@@ -30,7 +30,7 @@ Please note,
 
 1. For `_artifactsLocation`, please use the default value, `https://raw.githubusercontent.com/wls-eng/arm-oraclelinux-wls-admin/master/src/main/arm/`.
 
-2. For `wlsLDAPSSLCertificate`, please use base64 to encode you application gateway certificate, disable line wrapping and output to a file.  
+2. For `wlsLDAPSSLCertificate`, please use base64 to encode your AAD LDAP client certificate, disable line wrapping and output to a file.  
 
 ```
 base64 your-certificate.cer -w 0 >temp.txt
@@ -95,7 +95,7 @@ Run the following command to apply database service to your WebLogic Server.
 RESOURCE_GROUP=<resource-group-of-your-weblogic-server-instance>
 
 # cd nestedtemplates
-# Create parameters.json with above variables, and place it in the same folder with dbTemplate.json.
+# Create parameters.json with above variables, and place it in the same folder with aadNestedTemplate.json.
 az group deployment create --verbose --resource-group $RESOURCE_GROUP --name aad --parameters @parameters.json --template-file aadNestedTemplate.json
 ```
 

--- a/cluster/aadNestedTemplate.md
+++ b/cluster/aadNestedTemplate.md
@@ -30,7 +30,7 @@ Please note,
 
 1. For `_artifactsLocation`, please use the default value, `https://raw.githubusercontent.com/wls-eng/arm-oraclelinux-wls-admin/master/src/main/arm/`.
 
-2. For `wlsLDAPSSLCertificate`, please use base64 to encode you application gateway certificate, disable line wrapping and output to a file.  
+2. For `wlsLDAPSSLCertificate`, please use base64 to encode your AAD LDAP client certificate, disable line wrapping and output to a file.  
 
 ```
 base64 your-certificate.cer -w 0 >temp.txt
@@ -95,7 +95,7 @@ Run the following command to apply database service to your WebLogic Server.
 RESOURCE_GROUP=<resource-group-of-your-weblogic-server-instance>
 
 # cd nestedtemplates
-# Create parameters.json with above variables, and place it in the same folder with dbTemplate.json.
+# Create parameters.json with above variables, and place it in the same folder with aadNestedTemplate.json.
 az group deployment create --verbose --resource-group $RESOURCE_GROUP --name aad --parameters @parameters.json --template-file aadNestedTemplate.json
 ```
 

--- a/cluster/appGatewayNestedTemplate.md
+++ b/cluster/appGatewayNestedTemplate.md
@@ -22,7 +22,7 @@ Unzip the ARM template to your local machine, we will run nestedtemplates/appGat
 
 We need to specify information of exsiting WebLogic Server and application gateway, please create parameters.json with the following variables, and change the value to yours.
 
-First, use base64 to encode you application gateway certificate, and output to a file.  
+First, use base64 to encode your application gateway certificate, and output to a file.  
 
 ```
 base64 your-certificate.pfx -w 0 >temp.txt

--- a/dynamic-cluster/aadNestedTemplate.md
+++ b/dynamic-cluster/aadNestedTemplate.md
@@ -30,7 +30,7 @@ Please note,
 
 1. For `_artifactsLocation`, please use the default value, `https://raw.githubusercontent.com/wls-eng/arm-oraclelinux-wls-admin/master/src/main/arm/`.
 
-2. For `wlsLDAPSSLCertificate`, please use base64 to encode you application gateway certificate, disable line wrapping and output to a file.  
+2. For `wlsLDAPSSLCertificate`, please use base64 to encode your AAD LDAP client certificate, disable line wrapping and output to a file.  
 
 ```
 base64 your-certificate.cer -w 0 >temp.txt
@@ -95,7 +95,7 @@ Run the following command to apply database service to your WebLogic Server.
 RESOURCE_GROUP=<resource-group-of-your-weblogic-server-instance>
 
 # cd nestedtemplates
-# Create parameters.json with above variables, and place it in the same folder with dbTemplate.json.
+# Create parameters.json with above variables, and place it in the same folder with aadNestedTemplate.json.
 az group deployment create --verbose --resource-group $RESOURCE_GROUP --name aad --parameters @parameters.json --template-file aadNestedTemplate.json
 ```
 

--- a/index.md
+++ b/index.md
@@ -1,6 +1,0 @@
-# WebLogic Server with Admin Server
-[Apply Database Template to WebLogic Server with Admin Server Instance](admin/dbTemplate.md)  
-[Enable Azure Active Directory in an Existing WebLogic Server with Admin Server Instance](admin/aadNestedTemplate.md)
-
-# WebLogic Server Cluster
-[Set up Application Gateway to WebLogic Server Cluster Instance](cluster/appGatewayNestedTemplate.md)

--- a/subtemplate-src/aadNestedTemplate.md
+++ b/subtemplate-src/aadNestedTemplate.md
@@ -30,7 +30,7 @@ Please note,
 
 1. For `_artifactsLocation`, please use the default value, `https://raw.githubusercontent.com/wls-eng/arm-oraclelinux-wls-admin/master/src/main/arm/`.
 
-2. For `wlsLDAPSSLCertificate`, please use base64 to encode you application gateway certificate, disable line wrapping and output to a file.  
+2. For `wlsLDAPSSLCertificate`, please use base64 to encode your AAD LDAP client certificate, disable line wrapping and output to a file.  
 
 ```
 base64 your-certificate.cer -w 0 >temp.txt
@@ -95,7 +95,7 @@ Run the following command to apply database service to your WebLogic Server.
 RESOURCE_GROUP=<resource-group-of-your-weblogic-server-instance>
 
 # cd nestedtemplates
-# Create parameters.json with above variables, and place it in the same folder with dbTemplate.json.
+# Create parameters.json with above variables, and place it in the same folder with aadNestedTemplate.json.
 az group deployment create --verbose --resource-group $RESOURCE_GROUP --name aad --parameters @parameters.json --template-file aadNestedTemplate.json
 ```
 

--- a/subtemplate-src/appGatewayNestedTemplate.md
+++ b/subtemplate-src/appGatewayNestedTemplate.md
@@ -22,7 +22,7 @@ Unzip the ARM template to your local machine, we will run nestedtemplates/appGat
 
 We need to specify information of exsiting WebLogic Server and application gateway, please create parameters.json with the following variables, and change the value to yours.
 
-First, use base64 to encode you application gateway certificate, and output to a file.  
+First, use base64 to encode your application gateway certificate, and output to a file.  
 
 ```
 base64 your-certificate.pfx -w 0 >temp.txt


### PR DESCRIPTION
Modified admin/aadNestedTemplate.md
Fixed text of encoding aad client certificate.
Fixed template name.

Modified cluster/aadNestedTemplate.md
Fixed text of encoding aad client certificate.
Fixed template name.

Modified dynamic-cluster/aadNestedTemplate.md
Fixed text of encoding aad client certificate.
Fixed template name.

Modified subtemplate-src/aadNestedTemplate.md
Fixed text of encoding aad client certificate.
Fixed template name.

Modified cluster/appGatewayNestedTemplate.md
Fixed typos

Modified subtemplate-src/appGatewayNestedTemplate.md
Fixed typos

Removed index.md
We have index.md in admin, cluster, dynamic-cluster folder.