### PR TITLE
specify internalDnsNameLabel

### DIFF
--- a/src/main/arm/mainTemplate.json
+++ b/src/main/arm/mainTemplate.json
@@ -228,7 +228,10 @@
                      }
                   }
                }
-            ]
+            ],
+            "dnsSettings": {
+               "internalDnsNameLabel": "[parameters('vmName')]"
+            }
          }
       },
       {


### PR DESCRIPTION
Fix intermittent deployment failure caused by hostname that appending with `internal.cloudapp.net` by Network Manager after machine restart.

Doc for [internalDnsNameLabel](https://docs.microsoft.com/en-us/azure/templates/microsoft.network/networkinterfaces)
![image](https://user-images.githubusercontent.com/59823457/96097546-ac99a100-0f03-11eb-9637-2443412fe152.png)
``` text
Relative DNS name for this NIC used for internal communications between VMs in the same virtual network.
```