### PR TITLE
Updated to support latest base images

### DIFF
--- a/src/main/arm/createUiDefinition.json
+++ b/src/main/arm/createUiDefinition.json
@@ -8,29 +8,29 @@
                 "name": "skuUrnVersion",
                 "type": "Microsoft.Common.DropDown",
                 "label": "Oracle WebLogic Image",
-                "defaultValue": "WebLogic Server 12.2.1.3.0 and JDK8u131 on Oracle Linux 7.4",
+                "defaultValue": "WebLogic Server 14.1.1.0.0 and JDK11 on Oracle Linux 7.6",
                 "toolTip": "Choose Oracle WebLogic image, which is provided by Oracle, with Java and WebLogic preinstalled.",
                 "constraints": {
                     "allowedValues": [
                         {
-                            "label": "WebLogic Server 12.2.1.3.0 and JDK8u131 on Oracle Linux 7.4",
-                            "value": "owls-122130-8u131-ol74;Oracle:weblogic-122130-jdk8u131-ol74:owls-122130-8u131-ol7;1.1.1"
+                            "label": "WebLogic Server 12.2.1.3.0 and JDK8 on Oracle Linux 7.4",
+                            "value": "owls-122130-jdk8-ol74;Oracle:weblogic-122130-jdk8-ol74:owls-122130-jdk8-ol7;latest"
                         },
                         {
-                            "label": "WebLogic Server 12.2.1.3.0 and JDK8u131 on Oracle Linux 7.3",
-                            "value": "owls-122130-8u131-ol73;Oracle:weblogic-122130-jdk8u131-ol73:owls-122130-8u131-ol7;1.1.6"
+                            "label": "WebLogic Server 12.2.1.3.0 and JDK8 on Oracle Linux 7.3",
+                            "value": "owls-122130-jdk8-ol73;Oracle:weblogic-122130-jdk8-ol73:owls-122130-jdk8-ol7;latest"
                         },
                         {
-                            "label": "WebLogic Server 12.2.1.4.0 and JDK8u251 on Oracle Linux 7.6",
-                            "value": "owls-122140-8u251-ol76;Oracle:weblogic-122140-jdk8u251-ol76:owls-122140-8u251-ol7;1.1.1"
+                            "label": "WebLogic Server 12.2.1.4.0 and JDK8 on Oracle Linux 7.6",
+                            "value": "owls-122140-jdk8-ol76;Oracle:weblogic-122140-jdk8-ol76:owls-122140-jdk8-ol7;latest"
                         },
                         {
-                            "label": "WebLogic Server 14.1.1.0.0 and JDK8u251 on Oracle Linux 7.6",
-                            "value": "owls-141100-8u251-ol76;Oracle:weblogic-141100-jdk8u251-ol76:owls-141100-8u251-ol7;1.1.1"
+                            "label": "WebLogic Server 14.1.1.0.0 and JDK8 on Oracle Linux 7.6",
+                            "value": "owls-141100-jdk8-ol76;Oracle:weblogic-141100-jdk8-ol76:owls-141100-jdk8-ol7;latest"
                         },
                         {
-                            "label": "WebLogic Server 14.1.1.0.0 and JDK11_07 on Oracle Linux 7.6",
-                            "value": "owls-141100-11_07-ol76;Oracle:weblogic-141100-jdk11_07-ol76:owls-141100-11_07-ol7;1.1.1"
+                            "label": "WebLogic Server 14.1.1.0.0 and JDK11 on Oracle Linux 7.6",
+                            "value": "owls-141100-jdk11-ol76;Oracle:weblogic-141100-jdk11-ol76:owls-141100-jdk11-ol7;latest"
                         }
                     ],
                     "required": true

--- a/src/main/arm/mainTemplate.json
+++ b/src/main/arm/mainTemplate.json
@@ -52,13 +52,13 @@
       },
       "skuUrnVersion": {
          "type": "string",
-         "defaultValue": "owls-122130-8u131-ol74;Oracle:weblogic-122130-jdk8u131-ol74:owls-122130-8u131-ol7;1.1.1",
+         "defaultValue": "owls-141100-jdk11-ol76;Oracle:weblogic-141100-jdk11-ol76:owls-141100-jdk11-ol7;latest",
          "allowedValues": [
-            "owls-122130-8u131-ol73;Oracle:weblogic-122130-jdk8u131-ol73:owls-122130-8u131-ol7;1.1.6",
-            "owls-122130-8u131-ol74;Oracle:weblogic-122130-jdk8u131-ol74:owls-122130-8u131-ol7;1.1.1",
-            "owls-122140-8u251-ol76;Oracle:weblogic-122140-jdk8u251-ol76:owls-122140-8u251-ol7;1.1.1",
-            "owls-141100-8u251-ol76;Oracle:weblogic-141100-jdk8u251-ol76:owls-141100-8u251-ol7;1.1.1",
-            "owls-141100-11_07-ol76;Oracle:weblogic-141100-jdk11_07-ol76:owls-141100-11_07-ol7;1.1.1"
+            "owls-122130-jdk8-ol73;Oracle:weblogic-122130-jdk8-ol73:owls-122130-jdk8-ol7;latest",
+            "owls-122130-jdk8-ol74;Oracle:weblogic-122130-jdk8-ol74:owls-122130-jdk8-ol7;latest",
+            "owls-122140-jdk8-ol76;Oracle:weblogic-122140-jdk8-ol76:owls-122140-jdk8-ol7;latest",
+            "owls-141100-jdk8-ol76;Oracle:weblogic-141100-jdk8-ol76:owls-141100-jdk8-ol7;latest",
+            "owls-141100-jdk11-ol76;Oracle:weblogic-141100-jdk11-ol76:owls-141100-jdk11-ol7;latest"
          ],
          "metadata": {
             "description": "The Oracle Linux image with Weblogic and Java preinstalled. Semicolon separated string of Sku, URN, and Version"
@@ -95,7 +95,7 @@
    "variables": {
       "const_addressPrefix": "10.0.0.0/16",
       "const_hyphen": "-",
-      "const_imageOffer": "[concat('weblogic',variables('const_hyphen'), split(variables('name_linuxImageOfferSKU'),variables('const_hyphen'))[1],variables('const_hyphen'),'jdk',split(variables('name_linuxImageOfferSKU'),variables('const_hyphen'))[2],variables('const_hyphen'),split(variables('name_linuxImageOfferSKU'),variables('const_hyphen'))[3],if(parameters('usePreviewImage'),'-preview',''))]",
+      "const_imageOffer": "[concat('weblogic',variables('const_hyphen'), split(variables('name_linuxImageOfferSKU'),variables('const_hyphen'))[1],variables('const_hyphen'),split(variables('name_linuxImageOfferSKU'),variables('const_hyphen'))[2],variables('const_hyphen'),split(variables('name_linuxImageOfferSKU'),variables('const_hyphen'))[3],if(parameters('usePreviewImage'),'-preview',''))]",
       "const_imagePublisher": "oracle",
       "const_linuxConfiguration": {
          "disablePasswordAuthentication": true,
@@ -318,9 +318,9 @@
       },
       {
          "apiVersion": "2019-10-01",
-         "name": "${from.owls-122130-8u131-ol74}",
+         "name": "${from.owls-122130-jdk8-ol74}",
          "type": "Microsoft.Resources/deployments",
-         "condition": "[if(contains(variables('name_linuxImageOfferSKU'), 'owls-122130-8u131-ol74'), bool('true'), bool('false'))]",
+         "condition": "[if(contains(variables('name_linuxImageOfferSKU'), 'owls-122130-jdk8-ol74'), bool('true'), bool('false'))]",
          "dependsOn": [
             "[concat('Microsoft.Compute/virtualMachines/', parameters('vmName'))]"
          ],
@@ -336,9 +336,9 @@
       },
       {
          "apiVersion": "2019-10-01",
-         "name": "${from.owls-122130-8u131-ol73}",
+         "name": "${from.owls-122130-jdk8-ol73}",
          "type": "Microsoft.Resources/deployments",
-         "condition": "[if(contains(variables('name_linuxImageOfferSKU'), 'from.owls-122130-8u131-ol73'), bool('true'), bool('false'))]",
+         "condition": "[if(contains(variables('name_linuxImageOfferSKU'), 'from.owls-122130-jdk8-ol73'), bool('true'), bool('false'))]",
          "dependsOn": [
             "[concat('Microsoft.Compute/virtualMachines/', parameters('vmName'))]"
          ],
@@ -354,9 +354,9 @@
       },
       {
          "apiVersion": "2019-10-01",
-         "name": "${from.owls-122140-8u251-ol76}",
+         "name": "${from.owls-122140-jdk8-ol76}",
          "type": "Microsoft.Resources/deployments",
-         "condition": "[if(contains(variables('name_linuxImageOfferSKU'), 'from.owls-122140-8u251-ol76'), bool('true'), bool('false'))]",
+         "condition": "[if(contains(variables('name_linuxImageOfferSKU'), 'from.owls-122140-jdk8-ol76'), bool('true'), bool('false'))]",
          "dependsOn": [
             "[concat('Microsoft.Compute/virtualMachines/', parameters('vmName'))]"
          ],
@@ -372,9 +372,9 @@
       },
       {
          "apiVersion": "2019-10-01",
-         "name": "${from.owls-141100-8u251-ol76}",
+         "name": "${from.owls-141100-jdk8-ol76}",
          "type": "Microsoft.Resources/deployments",
-         "condition": "[if(contains(variables('name_linuxImageOfferSKU'), 'owls-141100-8u251-ol76'), bool('true'), bool('false'))]",
+         "condition": "[if(contains(variables('name_linuxImageOfferSKU'), 'owls-141100-jdk8-ol76'), bool('true'), bool('false'))]",
          "dependsOn": [
             "[concat('Microsoft.Compute/virtualMachines/', parameters('vmName'))]"
          ],
@@ -390,9 +390,9 @@
       },
       {
          "apiVersion": "2019-10-01",
-         "name": "${from.owls-141100-11_07-ol76}",
+         "name": "${from.owls-141100-jdk11-ol76}",
          "type": "Microsoft.Resources/deployments",
-         "condition": "[if(contains(variables('name_linuxImageOfferSKU'), 'owls-141100-11_07-ol76'), bool('true'), bool('false'))]",
+         "condition": "[if(contains(variables('name_linuxImageOfferSKU'), 'owls-141100-jdk11-ol76'), bool('true'), bool('false'))]",
          "dependsOn": [
             "[concat('Microsoft.Compute/virtualMachines/', parameters('vmName'))]"
          ],

--- a/src/main/resources/microsoft-pid.properties
+++ b/src/main/resources/microsoft-pid.properties
@@ -18,6 +18,7 @@
 #   under the License.
 
 azure.apiVersion=2020-06-01
+azure.apiVersion2=2019-06-01
 
 # Values in this file are read at build time for the other Azure Marketplace offer repositories
 
@@ -87,3 +88,11 @@ from.owls-122130-8u131-ol73=pid-bf1d0f1a-cb9a-5453-bf70-42b4efe8c15e
 from.owls-122140-8u251-ol76=pid-bde756bb-ce96-54d5-a478-04d9bd87e9db
 from.owls-141100-8u251-ol76=pid-b6f00a34-1478-5a10-9a84-49c4051b57b8
 from.owls-141100-11_07-ol76=pid-afc8f9c5-8c5d-5d1b-ab4d-3116ca908bfd
+
+# Pids to indicate which latest base image was chosen.  No difference in these
+# between Oracle and Microsoft
+from.owls-122130-jdk8-ol74=pid-caa3ea2b-cdec-55ee-8510-854ed10d7ebe
+from.owls-122130-jdk8-ol73=pid-bf1d0f1a-cb9a-5453-bf70-42b4efe8c15e
+from.owls-122140-jdk8-ol76=pid-bde756bb-ce96-54d5-a478-04d9bd87e9db
+from.owls-141100-jdk8-ol76=pid-b6f00a34-1478-5a10-9a84-49c4051b57b8
+from.owls-141100-jdk11-ol76=pid-afc8f9c5-8c5d-5d1b-ab4d-3116ca908bfd

--- a/src/main/resources/pid.properties
+++ b/src/main/resources/pid.properties
@@ -18,6 +18,7 @@
 #   under the License.
 
 azure.apiVersion=2020-06-01
+azure.apiVersion2=2019-06-01
 
 # Values in this file are read at build time for the other Azure Marketplace offer repositories
 
@@ -86,3 +87,11 @@ from.owls-122130-8u131-ol73=pid-2bd71be8-b31c-5fbf-96ba-61fde622586d
 from.owls-122140-8u251-ol76=pid-dd07bd44-828b-566a-8dc6-b84bf301bf1d
 from.owls-141100-8u251-ol76=pid-cb2af004-23c3-5c85-87b9-9de767c7a61e
 from.owls-141100-11_07-ol76=pid-632e8fde-e61f-57bf-af9d-5804bf00ecb3
+
+# Pids to indicate which latest base image was chosen.  No difference in these
+# between Oracle and Microsoft
+from.owls-122130-jdk8-ol74=pid-caa3ea2b-cdec-55ee-8510-854ed10d7ebe
+from.owls-122130-jdk8-ol73=pid-bf1d0f1a-cb9a-5453-bf70-42b4efe8c15e
+from.owls-122140-jdk8-ol76=pid-bde756bb-ce96-54d5-a478-04d9bd87e9db
+from.owls-141100-jdk8-ol76=pid-b6f00a34-1478-5a10-9a84-49c4051b57b8
+from.owls-141100-jdk11-ol76=pid-afc8f9c5-8c5d-5d1b-ab4d-3116ca908bfd


### PR DESCRIPTION
Updated offers to use new base images.

Changes are tested by manually doing azure deployment with latest skuUrnVersion.
Updated default value for skuUrnVersion to "WebLogic Server 14.1.1.0.0 and JDK11 on Oracle Linux 7.6"

